### PR TITLE
Add GitHub Actions workflow to auto-update papers data

### DIFF
--- a/.github/workflows/update-papers.yml
+++ b/.github/workflows/update-papers.yml
@@ -1,0 +1,94 @@
+name: "Update papers data"
+run-name: "📚 Update papers database"
+
+on:
+  schedule:
+    # Weekly, Monday 03:00 UTC
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/fetch_papers.py"
+      - "scripts/configs/conferences.jsonc"
+      - "requirements.txt"
+      - ".github/workflows/update-papers.yml"
+
+# Avoid overlapping runs writing data at the same time.
+concurrency:
+  group: update-papers-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate config & script
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate conference config parses
+        run: |
+          python3 - <<'PY'
+          import json
+          with open("scripts/configs/conferences.jsonc", encoding="utf-8") as f:
+              configs = json.load(f)
+          assert isinstance(configs, list) and configs, "config must be a non-empty list"
+          allowed = {"virtual_conference", "pmlr", "acl_anthology", "openreview"}
+          for c in configs:
+              assert "name" in c, f"missing name: {c}"
+              st = c.get("source_type", "virtual_conference")
+              assert st in allowed, f"unknown source_type {st!r} in {c['name']}"
+          print(f"OK: {len(configs)} conferences, source types valid")
+          PY
+
+      - name: Compile fetch script
+        run: python3 -m py_compile scripts/fetch_papers.py
+
+  update:
+    name: Fetch & commit papers
+    # Only refresh data on scheduled or manual runs, not on pull requests.
+    if: github.event_name != 'pull_request'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Fetch latest papers
+        run: python3 scripts/fetch_papers.py
+
+      - name: Commit updated data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/
+          if git diff --staged --quiet; then
+            echo "No data changes to commit."
+          else
+            git commit -m "chore: update papers data [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Summary

The README calls this an "auto-updating database", but there was no CI to actually do the updating. This adds a scheduled GitHub Actions workflow (`.github/workflows/update-papers.yml`) that keeps the data fresh — modeled on the example workflow shape (cron + `workflow_dispatch` + `pull_request`).

## What it does

Two jobs:

**`validate`** — runs on **every** trigger, including pull requests:
- Checks `scripts/configs/conferences.jsonc` parses and every `source_type` is one of the known kinds (`virtual_conference` / `pmlr` / `acl_anthology` / `openreview`).
- Compiles `scripts/fetch_papers.py`.
- Gives fast feedback on PRs that touch the pipeline (e.g. adding a new conference).

**`update`** — runs on **schedule / manual dispatch only** (`if: github.event_name != 'pull_request'`):
- Runs `python3 scripts/fetch_papers.py`.
- Commits any changed `data/` files back to the triggering branch using the built-in `GITHUB_TOKEN` (`permissions: contents: write`).

## Triggers

| Trigger | Purpose |
|---------|---------|
| `schedule` (cron `0 3 * * 1`) | Weekly refresh, Monday 03:00 UTC |
| `workflow_dispatch` | Manual run from the Actions tab |
| `pull_request` (pipeline paths) | Validate config/script changes before merge |

A `concurrency` group prevents overlapping runs from writing data simultaneously, and the auto-commit message carries `[skip ci]` so the data push doesn't retrigger the workflow.

## Design notes / decisions for review

- **Commit target**: the `update` job commits back to the branch it runs on. For scheduled runs that's the repository's default branch. If you'd rather the bot open a PR with data changes (instead of committing directly), or target a specific branch, that's a small change — flagging it since it touches your `develop` → `main` flow.
- **Scheduled triggers only fire once the workflow exists on the default branch**, so the weekly cron activates after this reaches `main`.
- **Python 3.11** is used (the script relies on `dict[str, Any]` / `list[...]` builtin generics; deps are just `httpx` + `PyYAML` from `requirements.txt`).

## Testing

- Workflow YAML parses; both jobs and all three triggers resolve.
- The embedded config-validation logic was run against the current `conferences.jsonc` (passes), and `py_compile` on the fetch script passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RC5S5BgtbTr5PYYWLQeuUz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC5S5BgtbTr5PYYWLQeuUz)_